### PR TITLE
fix: satisfy safe-navigation lint

### DIFF
--- a/lib/fizzy/cli/base.rb
+++ b/lib/fizzy/cli/base.rb
@@ -23,7 +23,7 @@ module Fizzy
 
       def account
         slug = global_options[:account]
-        slug = nil if slug&.empty?
+        slug = nil if slug && slug.empty?
         @account ||= Auth.resolve(slug || project_config.account)
       end
 


### PR DESCRIPTION
## Summary
- replace safe-navigation `empty?` conditional with an equivalent explicit nil guard
- restore compatibility with RuboCop 1.88.2 `Lint/SafeNavigationWithEmpty`

## Verification
- `bundle exec rubocop lib/fizzy/cli/base.rb` — 1 file, no offenses
- `bundle exec rake` — 114 runs, 262 assertions, 0 failures, 0 errors; 39 files, no RuboCop offenses
- `git diff --check`

This is a prerequisite for the separate `Gemfile.lock` cleanup PR #9, whose CI currently resolves RuboCop 1.88.2 and exposes this pre-existing warning.
